### PR TITLE
Cudl 1010 releases partitioned fail forward

### DIFF
--- a/.env
+++ b/.env
@@ -6,3 +6,4 @@ AWS_DEFAULT_REGION=eu-west-1
 API_HOST=host.docker.internal
 API_PATH=item
 API_PORT=80
+LOG_LEVEL=info

--- a/.env
+++ b/.env
@@ -7,3 +7,4 @@ API_HOST=host.docker.internal
 API_PATH=item
 API_PORT=80
 LOG_LEVEL=info
+RELEASES_PARTITIONED=true

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,9 @@
 /data/
 /venv/
 /test.log
+.DS_Store
+__pycache__/
+*.py[cod]
+.venv/
+*.egg-info/
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The Lambda function requires the following environment variables to be set:
 - `API_HOST`: The API host for submitting requests.
 - `API_PORT`: The port number of the API (optional).
 - `API_PATH`: The API path for the submission endpoint.
+- `RELEASES_PARTITIONED`: When set to `true`, DELETE requests include an `isReleased` query parameter derived from the object's root directory (`unreleased/...` → `false`, otherwise `true`). Optional; defaults to off.
 
 ## Local Build and Run
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The Lambda function requires the following environment variables to be set:
 - `API_PORT`: The port number of the API (optional).
 - `API_PATH`: The API path for the submission endpoint.
 - `RELEASES_PARTITIONED`: When set to `true`, DELETE requests include an `isReleased` query parameter derived from the object's root directory (`unreleased/...` → `false`, otherwise `true`). Optional; defaults to off.
+- `LOG_LEVEL`: Logging verbosity (e.g. `DEBUG`, `INFO`, `WARNING`, `ERROR`). Optional; defaults to `ERROR`.
 
 ## Local Build and Run
 

--- a/aws-lambda-listener/.dockerignore
+++ b/aws-lambda-listener/.dockerignore
@@ -1,1 +1,3 @@
 .DS_Store
+__pycache__/
+*.py[cod]

--- a/aws-lambda-listener/app.py
+++ b/aws-lambda-listener/app.py
@@ -62,6 +62,9 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     API_HOST: Optional[str] = os.environ.get("API_HOST")
     API_PORT: Optional[str] = os.environ.get("API_PORT", "")
     API_PATH: Optional[str] = os.environ.get("API_PATH")
+    RELEASES_PARTITIONED: bool = (
+        os.environ.get("RELEASES_PARTITIONED", "").lower() == "true"
+    )
 
     if not API_HOST:
         logger.error("ERROR: API_HOST environment variable not set")
@@ -163,6 +166,20 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
                 logger.info("Deleting %s using ID \"%s\"", json_file, id_val)
 
                 url = f"http://{API_HOST}:{API_PORT}/{API_PATH}/{id_val}"
+
+                if RELEASES_PARTITIONED:
+                    # Released and unreleased items are written to different locations
+                    root_dir = json_file.split("/")[0]
+                    item_released = root_dir != "unreleased"
+                    query = urllib.parse.urlencode(
+                        {"isReleased": str(item_released).lower()}
+                    )
+                    url = f"{url}?{query}"
+                    logger.info(
+                        "Releases partitioned; isReleased=%s",
+                        str(item_released).lower(),
+                    )
+
                 status_code = submit_request(method, url)
                 msg = {"http-code": status_code}
                 if not (status_code and 200 <= status_code < 300):

--- a/aws-lambda-listener/app.py
+++ b/aws-lambda-listener/app.py
@@ -9,7 +9,11 @@ from typing import Any, Dict, Optional
 
 # Configure logging to standard error.
 logger = logging.getLogger()
-logger.setLevel(logging.ERROR)  # INFO
+logger.setLevel(
+    logging.getLevelNamesMapping().get(
+        os.environ.get("LOG_LEVEL", "ERROR").upper(), logging.ERROR
+    )
+)
 
 # Compile a regex pattern to match any wildcard characters.
 WILDCARD_PATTERN = re.compile(r"[\*\?\{\}\[\]\|]")

--- a/aws-lambda-listener/app.py
+++ b/aws-lambda-listener/app.py
@@ -67,7 +67,7 @@ def submit_request(
 
 def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     logger.info("Parsing event notification")
-    logger.info(json.dumps(event))
+    logger.debug(json.dumps(event))
 
     API_HOST: Optional[str] = os.environ.get("API_HOST")
     API_PORT: Optional[str] = os.environ.get("API_PORT", "")

--- a/aws-lambda-listener/app.py
+++ b/aws-lambda-listener/app.py
@@ -9,12 +9,13 @@ from typing import Any, Dict, Optional
 
 # Configure logging to standard error.
 logger = logging.getLogger()
-logger.setLevel(logging.ERROR) #INFO
+logger.setLevel(logging.ERROR)  # INFO
 
 # Compile a regex pattern to match any wildcard characters.
-WILDCARD_PATTERN = re.compile(r'[\*\?\{\}\[\]\|]')
+WILDCARD_PATTERN = re.compile(r"[\*\?\{\}\[\]\|]")
 
-s3_client = boto3.client('s3')
+s3_client = boto3.client("s3")
+
 
 def download_s3_file(bucket: str, key: str, dest_path: str) -> None:
     """Download the file from S3 to a local path."""
@@ -22,27 +23,31 @@ def download_s3_file(bucket: str, key: str, dest_path: str) -> None:
     s3_client.download_file(bucket, key, dest_path)
     logger.info("File downloaded to %s", dest_path)
 
+
 def validate_json_file(filepath: str) -> bool:
     """Validate that the file is valid JSON."""
     try:
-        with open(filepath, 'r') as f:
+        with open(filepath, "r") as f:
             json.load(f)
         return True
     except Exception as e:
         logger.error("File validation failed: %s", e)
         return False
 
-def submit_request(method: str, url: str, file_path: Optional[str] = None) -> Optional[int]:
+
+def submit_request(
+    method: str, url: str, file_path: Optional[str] = None
+) -> Optional[int]:
     """Submit a request to the API endpoint.
 
     For PUT, file_path is used to send binary data.
     For DELETE, no file is sent.
     """
     logger.info("Submitting file via %s to %s", method, url)
-    headers = {'accept': 'application/json'}
+    headers = {"accept": "application/json"}
     try:
         if method == "PUT" and file_path:
-            with open(file_path, 'rb') as f:
+            with open(file_path, "rb") as f:
                 response = requests.put(url, headers=headers, data=f, timeout=120)
         elif method == "DELETE":
             response = requests.delete(url, timeout=120)
@@ -54,6 +59,7 @@ def submit_request(method: str, url: str, file_path: Optional[str] = None) -> Op
     except Exception as e:
         logger.error("Error submitting request: %s", e)
         return None
+
 
 def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     logger.info("Parsing event notification")
@@ -69,7 +75,9 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     if not API_HOST:
         logger.error("ERROR: API_HOST environment variable not set")
     if API_PORT == "":
-        logger.info("API_PORT not set; proceeding without port for ObjectCreated events")
+        logger.info(
+            "API_PORT not set; proceeding without port for ObjectCreated events"
+        )
     if not API_PATH:
         logger.error("ERROR: API_PATH environment variable not set")
 
@@ -86,7 +94,9 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
             event_name: str = inner.get("eventName", "")
             s3_info: Dict[str, Any] = inner.get("s3", {})
             s3_bucket: str = s3_info.get("bucket", {}).get("name", "")
-            json_file: str = urllib.parse.unquote_plus(s3_info.get("object", {}).get("key", ""))
+            json_file: str = urllib.parse.unquote_plus(
+                s3_info.get("object", {}).get("key", "")
+            )
 
             logger.info("Processing event: %s", event_name)
             logger.info("Bucket: %s, Key: %s", s3_bucket, json_file)
@@ -94,9 +104,13 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
             # Check for wildcard characters to avoid catastrophic deletes.
             if WILDCARD_PATTERN.search(json_file) or WILDCARD_PATTERN.search(s3_bucket):
                 if WILDCARD_PATTERN.search(json_file):
-                    logger.error("ERROR: File not processed because wildcard character in filename")
+                    logger.error(
+                        "ERROR: File not processed because wildcard character in filename"
+                    )
                 if WILDCARD_PATTERN.search(s3_bucket):
-                    logger.error("ERROR: File not processed because wildcard character in bucket name")
+                    logger.error(
+                        "ERROR: File not processed because wildcard character in bucket name"
+                    )
                 continue
 
             if not all([API_HOST, API_PATH, s3_bucket, json_file, event_name]):
@@ -137,7 +151,9 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
 
                 logger.info("Testing file is plausibly valid JSON")
                 if not validate_json_file(dest_path):
-                    logger.error("ERROR: File not submitted for reindexing because it doesn't seem valid")
+                    logger.error(
+                        "ERROR: File not submitted for reindexing because it doesn't seem valid"
+                    )
                     continue
                 logger.info("File OK")
 
@@ -158,12 +174,14 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
             elif method == "DELETE":
                 # Derive an ID by stripping .json or .collection.json suffixes.
                 basename = os.path.basename(json_file)
-                id_val = re.sub(r'(\.collection)?\.json$', '', basename)
+                id_val = re.sub(r"(\.collection)?\.json$", "", basename)
 
                 if not id_val:
-                    logger.error("ERROR: Could not derive an ID from filename %s", json_file)
+                    logger.error(
+                        "ERROR: Could not derive an ID from filename %s", json_file
+                    )
                     continue
-                logger.info("Deleting %s using ID \"%s\"", json_file, id_val)
+                logger.info('Deleting %s using ID "%s"', json_file, id_val)
 
                 url = f"http://{API_HOST}:{API_PORT}/{API_PATH}/{id_val}"
 

--- a/aws-lambda-listener/requirements.txt
+++ b/aws-lambda-listener/requirements.txt
@@ -1,3 +1,3 @@
-boto3==1.42.26
-requests==2.32.5
-urllib3==2.6.3
+boto3==1.43.18
+requests==2.34.2
+urllib3==2.7.0


### PR DESCRIPTION
This PR is related to https://github.com/cambridge-collection/cudl-solr/pull/9 and https://github.com/cambridge-collection/cudl-search/pull/23

Adds a `RELEASES_PARTITIONED` env var. When true, DELETE requests to the indexer API carry an isReleased query parameter inferred from the S3 key's root directory (unreleased/... → false, otherwise true), so the API knows which partition to remove the item from. Off by default, so existing deploys are unaffected.

Also adds a `LOG_LEVEL` env var to control logging verbosity (default `ERROR`), demotes the full event JSON to DEBUG, bumps boto3/requests/urllib3, formats app.py with black, and extends .gitignore/.dockerignore.